### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting assignment

### DIFF
--- a/EasyConnectSPA/src/app/members/member-detail/member-detail.component.ts
+++ b/EasyConnectSPA/src/app/members/member-detail/member-detail.component.ts
@@ -32,8 +32,11 @@ export class MemberDetailComponent implements OnInit, OnDestroy {
     });
 
     this.route.queryParams.subscribe((params) => {
-      const selectedTab = params['tab'];
-      this.memberTabs.tabs[selectedTab > 0 ? selectedTab : 0].active = true;
+      let selectedTab = parseInt(params['tab'], 10);
+      if (isNaN(selectedTab) || selectedTab < 0 || selectedTab >= this.memberTabs.tabs.length) {
+        selectedTab = 0;
+      }
+      this.memberTabs.tabs[selectedTab].active = true;
     });
   }
 


### PR DESCRIPTION
Fixes [https://github.com/akazad13/easy-connect/security/code-scanning/2](https://github.com/akazad13/easy-connect/security/code-scanning/2)

To fix the problem, we need to ensure that the `selectedTab` value cannot be set to a property that could lead to prototype pollution. We can achieve this by validating the `selectedTab` value to ensure it is a valid index within the bounds of the `this.memberTabs.tabs` array. This approach maintains the existing functionality while preventing malicious input from causing prototype pollution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
